### PR TITLE
Seungjun/user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ repositories {
 }
 
 dependencies {
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/com/sparta/review/CommonResponseDto.java
+++ b/src/main/java/com/sparta/review/CommonResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.review;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommonResponseDto {
+    private String msg;
+    private Integer statusCode;
+}

--- a/src/main/java/com/sparta/review/SecurityConfig.java
+++ b/src/main/java/com/sparta/review/SecurityConfig.java
@@ -1,8 +1,15 @@
 package com.sparta.review;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.review.jwt.JwtFilter;
+import com.sparta.review.jwt.JwtUtil;
+import com.sparta.review.user.details.UserDetailsService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,11 +20,27 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig {
+@RequiredArgsConstructor
+public class SecurityConfig{
+
+    private final JwtUtil jwtUtil;
+
+    private final UserDetailsService userDetailsService;
+
+    private final ObjectMapper objectMapper;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+    @Bean
+    public JwtFilter jwtFilter() {
+        return new JwtFilter(jwtUtil, userDetailsService, objectMapper);
     }
 
     @Bean
@@ -38,7 +61,7 @@ public class SecurityConfig {
         );
 
         // 필터 관리
-//        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/sparta/review/SecurityConfig.java
+++ b/src/main/java/com/sparta/review/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.sparta.review;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf((csrf) -> csrf.disable());
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                        .requestMatchers("/api/users/**").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+        );
+
+        // 필터 관리
+//        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/sparta/review/jwt/JwtFilter.java
+++ b/src/main/java/com/sparta/review/jwt/JwtFilter.java
@@ -1,0 +1,63 @@
+package com.sparta.review.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.review.CommonResponseDto;
+import com.sparta.review.user.details.UserDetailsImpl;
+import com.sparta.review.user.details.UserDetailsService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = jwtUtil.resolveToken(request);
+
+        if(Objects.nonNull(token)) {
+            if(jwtUtil.validateToken(token)) {
+                Claims info = jwtUtil.getUserInfoFromToken(token);
+
+                // 인증정보에 요저정보(username) 넣기
+                // username -> user 조회
+                String nickname = info.getSubject();
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                // -> userDetails 에 담고
+                UserDetailsImpl userDetails = userDetailsService.getUserDetails(nickname);
+                // -> authentication의 principal 에 담고
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                // -> securityContent 에 담고
+                context.setAuthentication(authentication);
+                // -> SecurityContextHolder 에 담고
+                SecurityContextHolder.setContext(context);
+                // -> 이제 @AuthenticationPrincipal 로 조회할 수 있음
+            } else {
+                // 인증정보가 존재하지 않을때
+                CommonResponseDto commonResponseDto = new CommonResponseDto("토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST.value());
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.setContentType("application/json; charset=UTF-8");
+                response.getWriter().write(objectMapper.writeValueAsString(commonResponseDto));
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sparta/review/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/review/jwt/JwtUtil.java
@@ -1,0 +1,78 @@
+package com.sparta.review.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    public String createToken(String username) {
+        Date date = new Date();
+
+        // 토큰 만료시간 60분
+        long TOKEN_TIME = 60 * 60 * 1000;
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(username)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+}

--- a/src/main/java/com/sparta/review/user/controller/UserController.java
+++ b/src/main/java/com/sparta/review/user/controller/UserController.java
@@ -1,0 +1,48 @@
+package com.sparta.review.user.controller;
+
+import com.sparta.review.CommonResponseDto;
+import com.sparta.review.user.dto.UserRequestDto;
+import com.sparta.review.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<CommonResponseDto> signup(@RequestBody @Valid UserRequestDto userRequestDto, BindingResult bindingResult) {
+        // Validation 결과 확인
+        if (bindingResult.hasErrors()) {
+            StringBuilder errorMessage = new StringBuilder();
+            for (FieldError error : bindingResult.getFieldErrors()) {
+                errorMessage.append(error.getDefaultMessage()).append("; ");
+            }
+            return ResponseEntity.badRequest().body(new CommonResponseDto(errorMessage.toString(), HttpStatus.BAD_REQUEST.value()));
+        }
+        // 회원가입 로직
+        try {
+            userService.signup(userRequestDto);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(new CommonResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
+
+        return ResponseEntity.ok().body(new CommonResponseDto("회원가입을 완료했습니다.", HttpStatus.OK.value()));
+    }
+
+    @PostMapping("/check-nickname")
+    public String checkNickname(@RequestParam String nickname) {
+        if (userService.isNicknameExists(nickname)) {
+            return "닉네임이 이미 사용 중입니다.";
+        } else {
+            return "사용 가능한 닉네임입니다.";
+        }
+    }
+}

--- a/src/main/java/com/sparta/review/user/controller/UserController.java
+++ b/src/main/java/com/sparta/review/user/controller/UserController.java
@@ -1,22 +1,34 @@
 package com.sparta.review.user.controller;
 
 import com.sparta.review.CommonResponseDto;
+import com.sparta.review.jwt.JwtFilter;
+import com.sparta.review.jwt.JwtUtil;
 import com.sparta.review.user.dto.UserRequestDto;
 import com.sparta.review.user.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
-
+    private final JwtUtil jwtUtil;
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto> signup(@RequestBody @Valid UserRequestDto userRequestDto, BindingResult bindingResult) {
         // Validation 결과 확인
@@ -44,5 +56,20 @@ public class UserController {
         } else {
             return "사용 가능한 닉네임입니다.";
         }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponseDto> login(@RequestParam String nickname, @RequestParam String password, HttpServletResponse response) throws UnsupportedEncodingException {
+        try {
+            userService.login(nickname, password);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(new CommonResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
+
+        String token = jwtUtil.createToken(nickname);
+        token = URLEncoder.encode(token, "UTF-8");
+        // 클라이언트에게 JWT를 Cookie로 전달
+        response.addCookie(new Cookie(JwtUtil.AUTHORIZATION_HEADER, token));
+        return ResponseEntity.ok().body(new CommonResponseDto("로그인을 완료했습니다.", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/sparta/review/user/details/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/review/user/details/UserDetailsImpl.java
@@ -1,0 +1,53 @@
+package com.sparta.review.user.details;
+
+import com.sparta.review.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+
+    @Getter
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getNickname();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/sparta/review/user/details/UserDetailsService.java
+++ b/src/main/java/com/sparta/review/user/details/UserDetailsService.java
@@ -1,0 +1,21 @@
+package com.sparta.review.user.details;
+
+import com.sparta.review.user.entity.User;
+import com.sparta.review.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsImpl getUserDetails(String nickname) {
+        User user = userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found" + nickname));
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/sparta/review/user/dto/UserRequestDto.java
+++ b/src/main/java/com/sparta/review/user/dto/UserRequestDto.java
@@ -1,0 +1,21 @@
+package com.sparta.review.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UserRequestDto {
+    @NotBlank(message = "닉네임을 입력하세요.")
+    @Size(min = 3, message = "닉네임은 최소 3자 이상이어야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "닉네임은 알파벳 대소문자 및 숫자로만 구성되어야 합니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 4, message = "비밀번호는 최소 4자 이상이어야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인을 입력하세요.")
+    private String confirmPassword;
+}

--- a/src/main/java/com/sparta/review/user/entity/User.java
+++ b/src/main/java/com/sparta/review/user/entity/User.java
@@ -1,0 +1,26 @@
+package com.sparta.review.user.entity;
+
+import com.sparta.review.user.dto.UserRequestDto;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    public User(String nickname, String encode) {
+        this.nickname = nickname;
+        this.password = encode;
+    }
+}

--- a/src/main/java/com/sparta/review/user/entity/User.java
+++ b/src/main/java/com/sparta/review/user/entity/User.java
@@ -5,9 +5,12 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor
+@Table
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sparta/review/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/review/user/repository/UserRepository.java
@@ -3,6 +3,10 @@ package com.sparta.review.user.repository;
 import com.sparta.review.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/sparta/review/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/review/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.review.user.repository;
+
+import com.sparta.review.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/sparta/review/user/service/UserService.java
+++ b/src/main/java/com/sparta/review/user/service/UserService.java
@@ -1,0 +1,40 @@
+package com.sparta.review.user.service;
+
+import com.sparta.review.user.dto.UserRequestDto;
+import com.sparta.review.user.entity.User;
+import com.sparta.review.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    public void signup(UserRequestDto userRequestDto) {
+        String nickname = userRequestDto.getNickname();
+        String password = userRequestDto.getPassword();
+        String confirmPassword = userRequestDto.getConfirmPassword();
+
+        // 닉네임과 같은 값이 포함된 경우 회원가입에 실패로 만들기
+        if (password.contains(nickname)) {
+            throw new IllegalArgumentException("Registration failed: 비밀번호에 닉네임이 포함되어 있습니다.");
+        }
+        // 비밀번호 확인은 비밀번호와 정확하게 일치하기
+        if (!password.equals(confirmPassword)) {
+            throw new IllegalArgumentException("Registration failed: 비밀번호 확인이 일치하지 않습니다.");
+        }
+        // 데이터베이스에 존재하는 닉네임을 입력한 채 회원가입 버튼을 누른 경우
+        if (isNicknameExists(nickname)) {
+            throw new IllegalArgumentException("Registration failed: 중복된 닉네임입니다.");
+        }
+
+        User user = new User(nickname, passwordEncoder.encode(password));
+        userRepository.save(user);
+    }
+
+    public boolean isNicknameExists(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+}

--- a/src/main/java/com/sparta/review/user/service/UserService.java
+++ b/src/main/java/com/sparta/review/user/service/UserService.java
@@ -4,9 +4,11 @@ import com.sparta.review.user.dto.UserRequestDto;
 import com.sparta.review.user.entity.User;
 import com.sparta.review.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -36,5 +38,12 @@ public class UserService {
 
     public boolean isNicknameExists(String nickname) {
         return userRepository.existsByNickname(nickname);
+    }
+
+    public void login(String nickname, String password) {
+        User user = userRepository.findByNickname(nickname).orElseThrow(() -> new IllegalArgumentException("Login failed: 닉네임 또는 패스워드를 확인해주세요."));
+        if(!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("Login failed: 닉네임 또는 패스워드를 확인해주세요.");
+        }
     }
 }


### PR DESCRIPTION
회원가입 기능
    -  닉네임, 비밀번호, 비밀번호 확인을 request에서 전달받기
    -  닉네임은 최소 3자 이상, 알파벳 대소문자(a~z, A~Z), 숫자(0~9)로 구성하기
    -  비밀번호는 최소 4자 이상이며, 닉네임과 같은 값이 포함된 경우 회원가입에 실패로 만들기
    -  비밀번호 확인은 비밀번호와 정확하게 일치하기
    -  데이터베이스에 존재하는 닉네임을 입력한 채 회원가입 버튼을 누른 경우 "중복된 닉네임입니다." 라는 에러메세지를 response에 포함하기
    -  회원 가입 버튼을 누르기 전, 같은 닉네임이 존재하는지 "확인" 버튼을 눌러 먼저 유효성 검증부터 할 수 있도록 해보기
    -  (챌린지 과제) 데이터베이스에 비밀번호를 평문으로 저장하는 것이 아닌, 단방향 암호화 알고리즘을 이용하여 암호화 해서 저장하도록 하기
로그인 기능
    - 닉네임, 비밀번호를 request에서 전달받기
    - 로그인 버튼을 누른 경우 닉네임과 비밀번호가 데이터베이스에 등록됐는지 확인한 뒤, 하나라도 맞지 않는 정보가 있다면 "닉네임 또는 패스워드를 확인해주세요."라는 에러 메세지를 response에 포함하기
    - 로그인 성공 시, 로그인에 성공한 유저의 정보를 JWT를 활용하여 클라이언트에게 Cookie로 전달하기