### PR TITLE
Seungjun/comment

### DIFF
--- a/src/main/java/com/sparta/review/SecurityConfig.java
+++ b/src/main/java/com/sparta/review/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig{
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/api/users/**").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
                         .requestMatchers("/api/posts/**").permitAll()
+                        .requestMatchers("/api/comments/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );
 

--- a/src/main/java/com/sparta/review/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/review/comment/controller/CommentController.java
@@ -2,7 +2,10 @@ package com.sparta.review.comment.controller;
 
 import com.sparta.review.CommonResponseDto;
 import com.sparta.review.comment.dto.CommentRequestDto;
+import com.sparta.review.comment.dto.CommentResponseDto;
 import com.sparta.review.comment.service.CommentService;
+import com.sparta.review.post.dto.PostRequestDto;
+import com.sparta.review.post.dto.PostResponseDto;
 import com.sparta.review.user.details.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -36,5 +39,25 @@ public class CommentController {
     public ResponseEntity<CommonResponseDto> postComment(@PathVariable Long post_id, @RequestBody @Valid CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         commentService.postComment(post_id, commentRequestDto, userDetails.getUser());
         return ResponseEntity.ok().body(new CommonResponseDto("댓글 작성을 완료했습니다.", HttpStatus.OK.value()));
+    }
+
+    @PatchMapping("/{comment_id}")
+    public ResponseEntity<CommonResponseDto> patchPost(@PathVariable Long comment_id, @RequestBody @Valid PostRequestDto postRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        try {
+            CommentResponseDto commentResponseDto = commentService.patchComment(comment_id, postRequestDto,userDetails.getUser());
+            return ResponseEntity.ok().body(commentResponseDto);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(new CommonResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
+    }
+
+    @DeleteMapping("/{comment_id}")
+    public ResponseEntity<CommonResponseDto> deletePost(@PathVariable Long comment_id,@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        try {
+            commentService.deleteComment(comment_id,userDetails.getUser());
+            return ResponseEntity.ok().body(new CommonResponseDto("댓글 삭제를 완료했습니다.", HttpStatus.OK.value()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(new CommonResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
     }
 }

--- a/src/main/java/com/sparta/review/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/review/comment/controller/CommentController.java
@@ -1,11 +1,11 @@
 package com.sparta.review.comment.controller;
 
 import com.sparta.review.CommonResponseDto;
+import com.sparta.review.comment.dto.CommentListResponseDto;
 import com.sparta.review.comment.dto.CommentRequestDto;
 import com.sparta.review.comment.dto.CommentResponseDto;
 import com.sparta.review.comment.service.CommentService;
 import com.sparta.review.post.dto.PostRequestDto;
-import com.sparta.review.post.dto.PostResponseDto;
 import com.sparta.review.user.details.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,8 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/comments")
@@ -39,6 +41,13 @@ public class CommentController {
     public ResponseEntity<CommonResponseDto> postComment(@PathVariable Long post_id, @RequestBody @Valid CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         commentService.postComment(post_id, commentRequestDto, userDetails.getUser());
         return ResponseEntity.ok().body(new CommonResponseDto("댓글 작성을 완료했습니다.", HttpStatus.OK.value()));
+    }
+
+    @GetMapping("{post_id}")
+    public ResponseEntity<List<CommentListResponseDto>> getCommentList(@PathVariable Long post_id) {
+        List<CommentListResponseDto> commentListResponseDtos = commentService.getCommentList(post_id);
+
+        return ResponseEntity.ok().body(commentListResponseDtos);
     }
 
     @PatchMapping("/{comment_id}")

--- a/src/main/java/com/sparta/review/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/review/comment/controller/CommentController.java
@@ -1,15 +1,18 @@
 package com.sparta.review.comment.controller;
 
+import com.sparta.review.CommonResponseDto;
 import com.sparta.review.comment.dto.CommentRequestDto;
 import com.sparta.review.comment.service.CommentService;
 import com.sparta.review.user.details.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/comments")
@@ -17,8 +20,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
     private final CommentService commentService;
 
-    @PostMapping
-    public ResponseEntity<CommentService> postComment(@RequestBody CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    // 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<CommonResponseDto> handleValidationException(MethodArgumentNotValidException ex) {
+        BindingResult result = ex.getBindingResult();
+        FieldError fieldError = result.getFieldError();
+        String errorMessage = fieldError.getDefaultMessage();
 
+        CommonResponseDto responseDto = new CommonResponseDto(errorMessage, HttpStatus.BAD_REQUEST.value());
+        return ResponseEntity.badRequest().body(responseDto);
+    }
+
+    @PostMapping("/{post_id}")
+    public ResponseEntity<CommonResponseDto> postComment(@PathVariable Long post_id, @RequestBody @Valid CommentRequestDto commentRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.postComment(post_id, commentRequestDto, userDetails.getUser());
+        return ResponseEntity.ok().body(new CommonResponseDto("댓글 작성을 완료했습니다.", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/sparta/review/comment/dto/CommentListResponseDto.java
+++ b/src/main/java/com/sparta/review/comment/dto/CommentListResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.review.comment.dto;
+
+import com.sparta.review.CommonResponseDto;
+import com.sparta.review.comment.entity.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentListResponseDto extends CommonResponseDto {
+    private final Long id;
+    private final String content;
+    private final LocalDateTime createdAt;
+
+    public CommentListResponseDto(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+    }
+}

--- a/src/main/java/com/sparta/review/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/review/comment/dto/CommentRequestDto.java
@@ -1,5 +1,12 @@
 package com.sparta.review.comment.dto;
 
-public class CommentRequestDto {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
 
+@Getter
+public class CommentRequestDto {
+    @NotBlank(message = "내용을 입력하세요.")
+    @Size(max = 500, message = "내용은 500자 까지 입력 가능합니다.")
+    private String content;
 }

--- a/src/main/java/com/sparta/review/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/review/comment/dto/CommentResponseDto.java
@@ -1,0 +1,15 @@
+package com.sparta.review.comment.dto;
+
+import com.sparta.review.CommonResponseDto;
+import com.sparta.review.comment.entity.Comment;
+import com.sparta.review.post.dto.PostResponseDto;
+import lombok.Getter;
+
+@Getter
+public class CommentResponseDto extends CommonResponseDto {
+    private final String content;
+
+    public CommentResponseDto(Comment comment) {
+        this.content = comment.getContent();
+    }
+}

--- a/src/main/java/com/sparta/review/comment/entity/Comment.java
+++ b/src/main/java/com/sparta/review/comment/entity/Comment.java
@@ -1,15 +1,18 @@
 package com.sparta.review.comment.entity;
 
 import com.sparta.review.Timestamped;
+import com.sparta.review.comment.dto.CommentRequestDto;
 import com.sparta.review.post.entity.Post;
 import com.sparta.review.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Entity
+@NoArgsConstructor
 public class Comment extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,4 +28,10 @@ public class Comment extends Timestamped {
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public Comment(CommentRequestDto commentRequestDto, User user, Post post) {
+        this.content = commentRequestDto.getContent();
+        this.post = post;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/sparta/review/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/review/comment/repository/CommentRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByOrderByCreatedAtDesc();
+    List<Comment> findByPostIdOrderByCreatedAtDesc(Long postId);
 }

--- a/src/main/java/com/sparta/review/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/review/comment/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package com.sparta.review.comment.repository;
 import com.sparta.review.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/sparta/review/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/review/comment/service/CommentService.java
@@ -5,9 +5,7 @@ import com.sparta.review.comment.dto.CommentRequestDto;
 import com.sparta.review.comment.dto.CommentResponseDto;
 import com.sparta.review.comment.entity.Comment;
 import com.sparta.review.comment.repository.CommentRepository;
-import com.sparta.review.post.dto.PostListResponseDto;
 import com.sparta.review.post.dto.PostRequestDto;
-import com.sparta.review.post.dto.PostResponseDto;
 import com.sparta.review.post.entity.Post;
 import com.sparta.review.post.repository.PostRepository;
 import com.sparta.review.user.entity.User;
@@ -55,7 +53,7 @@ public class CommentService {
     }
 
     public List<CommentListResponseDto> getCommentList(Long postId) {
-        List<Comment> commentList = commentRepository.findAllByOrderByCreatedAtDesc();
+        List<Comment> commentList = commentRepository.findByPostIdOrderByCreatedAtDesc(postId);
 
         List<CommentListResponseDto> commentListResponseDtos = new ArrayList<>();
         for (Comment comment : commentList) {

--- a/src/main/java/com/sparta/review/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/review/comment/service/CommentService.java
@@ -1,6 +1,11 @@
 package com.sparta.review.comment.service;
 
+import com.sparta.review.comment.dto.CommentRequestDto;
+import com.sparta.review.comment.entity.Comment;
 import com.sparta.review.comment.repository.CommentRepository;
+import com.sparta.review.post.entity.Post;
+import com.sparta.review.post.repository.PostRepository;
+import com.sparta.review.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,4 +13,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    public void postComment(Long post_id, CommentRequestDto commentRequestDto, User user) {
+        Post post = postRepository.findById(post_id).orElseThrow(() -> new IllegalArgumentException("해당 게시글은 없습니다."));
+
+        Comment comment = new Comment(commentRequestDto, user, post);
+
+        commentRepository.save(comment);
+    }
 }

--- a/src/main/java/com/sparta/review/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/review/comment/service/CommentService.java
@@ -1,9 +1,11 @@
 package com.sparta.review.comment.service;
 
+import com.sparta.review.comment.dto.CommentListResponseDto;
 import com.sparta.review.comment.dto.CommentRequestDto;
 import com.sparta.review.comment.dto.CommentResponseDto;
 import com.sparta.review.comment.entity.Comment;
 import com.sparta.review.comment.repository.CommentRepository;
+import com.sparta.review.post.dto.PostListResponseDto;
 import com.sparta.review.post.dto.PostRequestDto;
 import com.sparta.review.post.dto.PostResponseDto;
 import com.sparta.review.post.entity.Post;
@@ -12,6 +14,8 @@ import com.sparta.review.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -48,5 +52,16 @@ public class CommentService {
         }
 
         commentRepository.delete(comment);
+    }
+
+    public List<CommentListResponseDto> getCommentList(Long postId) {
+        List<Comment> commentList = commentRepository.findAllByOrderByCreatedAtDesc();
+
+        List<CommentListResponseDto> commentListResponseDtos = new ArrayList<>();
+        for (Comment comment : commentList) {
+            commentListResponseDtos.add(new CommentListResponseDto(comment));
+        }
+
+        return commentListResponseDtos;
     }
 }

--- a/src/main/java/com/sparta/review/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/review/comment/service/CommentService.java
@@ -1,13 +1,18 @@
 package com.sparta.review.comment.service;
 
 import com.sparta.review.comment.dto.CommentRequestDto;
+import com.sparta.review.comment.dto.CommentResponseDto;
 import com.sparta.review.comment.entity.Comment;
 import com.sparta.review.comment.repository.CommentRepository;
+import com.sparta.review.post.dto.PostRequestDto;
+import com.sparta.review.post.dto.PostResponseDto;
 import com.sparta.review.post.entity.Post;
 import com.sparta.review.post.repository.PostRepository;
 import com.sparta.review.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -21,5 +26,27 @@ public class CommentService {
         Comment comment = new Comment(commentRequestDto, user, post);
 
         commentRepository.save(comment);
+    }
+
+    public CommentResponseDto patchComment(Long commentId, PostRequestDto postRequestDto, User user) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("해당 댓글이 없습니다."));
+
+        if (!Objects.equals(comment.getUser().getId(), user.getId())) {
+            throw new IllegalArgumentException("댓글 작성자만 수정이 가능합니다.");
+        }
+
+        comment.setContent(postRequestDto.getContent());
+
+        return new CommentResponseDto(comment);
+    }
+
+    public void deleteComment(Long commentId, User user) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("해당 댓글이 없습니다."));
+
+        if (!Objects.equals(comment.getUser().getId(), user.getId())) {
+            throw new IllegalArgumentException("댓글 작성자만 수정이 가능합니다.");
+        }
+
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/sparta/review/post/controller/PostController.java
+++ b/src/main/java/com/sparta/review/post/controller/PostController.java
@@ -66,7 +66,7 @@ public class PostController {
     }
 
     @PatchMapping("/{post_id}")
-    public ResponseEntity<CommonResponseDto> patchPost(@PathVariable Long post_id, @RequestBody PostRequestDto postRequestDto,@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<CommonResponseDto> patchPost(@PathVariable Long post_id, @RequestBody @Valid PostRequestDto postRequestDto,@AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             PostResponseDto postResponseDto = postService.patchPost(post_id, postRequestDto,userDetails.getUser());
             return ResponseEntity.ok().body(postResponseDto);

--- a/src/main/java/com/sparta/review/post/dto/PostRequestDto.java
+++ b/src/main/java/com/sparta/review/post/dto/PostRequestDto.java
@@ -1,7 +1,6 @@
 package com.sparta.review.post.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 

--- a/src/main/java/com/sparta/review/post/dto/PostResponseDto.java
+++ b/src/main/java/com/sparta/review/post/dto/PostResponseDto.java
@@ -1,11 +1,13 @@
 package com.sparta.review.post.dto;
 
 import com.sparta.review.CommonResponseDto;
+import com.sparta.review.comment.dto.CommentResponseDto;
 import com.sparta.review.post.entity.Post;
 import lombok.Getter;
 
-import java.lang.management.LockInfo;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class PostResponseDto extends CommonResponseDto {
@@ -13,11 +15,13 @@ public class PostResponseDto extends CommonResponseDto {
     private final String title;
     private final String content;
     private final LocalDateTime createdAt;
+    private final List<CommentResponseDto> commentList;
 
     public PostResponseDto(Post post) {
         this.id = post.getId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.createdAt = post.getCreatedAt();
+        this.commentList = post.getCommentList().stream().map(CommentResponseDto::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/sparta/review/post/service/PostService.java
+++ b/src/main/java/com/sparta/review/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.sparta.review.post.service;
 
+import com.sparta.review.comment.entity.Comment;
+import com.sparta.review.comment.repository.CommentRepository;
 import com.sparta.review.post.dto.PostListResponseDto;
 import com.sparta.review.post.dto.PostRequestDto;
 import com.sparta.review.post.dto.PostResponseDto;
@@ -8,16 +10,19 @@ import com.sparta.review.post.repository.PostRepository;
 import com.sparta.review.user.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     public void createPost(PostRequestDto postRequestDto, User user) {
         Post post = new Post(postRequestDto, user);
@@ -26,6 +31,10 @@ public class PostService {
 
     public PostResponseDto getPost(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 게시글은 없습니다."));
+
+        List<Comment> commentList = commentRepository.findByPostIdOrderByCreatedAtDesc(postId);
+        post.setCommentList(commentList);
+
         return new PostResponseDto(post);
     }
 


### PR DESCRIPTION
댓글 작성 API
    - 게시글과 연관 관계를 가진 댓글 테이블 추가
    - 토큰을 검사하여, 유효한 토큰일 경우에만 게시글 작성 가능
    - 작성 내용을 입력하기

게시글과 댓글 목록 조회 API, 댓글 수정/삭제 API
    - 댓글 목록 조회
    - 게시글 조회 API 호출시 해당 게시글의 댓글 목록도 응답
    - 토큰을 검사하여, 해당 사용자가 작성한 댓글만 수정/삭제 가능